### PR TITLE
fix: use only declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
         "baseUrl": "./",
-        "declaration": true,
-        "declarationMap": true,
         "rootDir": "src",
         "outDir": "dist",
         "target": "ES2021",
@@ -22,7 +20,9 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,
-        "sourceMap": true,
+        "sourceMap": false,
+        "declaration": true,
+        "declarationMap": true,
         "types": [
             "node"
         ],


### PR DESCRIPTION
there's no need to keep `sourceMap` if we're already using `declarationMap`, this will help decrease the shipped build size a little more