### PR TITLE
fix: use rmSync only for sub-dir with resursive flag & not fall outside

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -44,7 +44,7 @@ describe('test remove-glob CLI', () => {
     expect(existsSync('./tests')).toBeTruthy();
 
     expect(() => removeSync({ paths: 'file1.txt', glob: 'dist/**' })).toThrow(
-      'Providing both `--paths` and `--glob` pattern are not supported, you must provide only one of these options.',
+      'Providing both `--paths` and `--glob` pattern at the same time is not supported, you must chose only one.',
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export function removeSync(opts: RemoveOptions = {}, callback?: (e?: Error) => v
   }
   if (paths.length && opts.glob) {
     throwOrCallback(
-      new Error('Providing both `--paths` and `--glob` pattern are not supported, you must provide only one of these options.'),
+      new Error('Providing both `--paths` and `--glob` pattern at the same time is not supported, you must chose only one.'),
       cb,
     );
     return;
@@ -69,9 +69,6 @@ export function removeSync(opts: RemoveOptions = {}, callback?: (e?: Error) => v
           console.log(`would remove directory: ${path}`);
         } else {
           opts.verbose && console.log(`removing directory: ${path}`);
-          readdirSync(path).forEach(name => {
-            removeSync({ paths: join(path, name) }); // recursively remove content
-          });
           rmSync(path, { recursive: true, force: true, maxRetries: process.platform === 'win32' ? 10 : 0 });
         }
       } else {
@@ -92,6 +89,6 @@ export function removeSync(opts: RemoveOptions = {}, callback?: (e?: Error) => v
     console.timeEnd('Duration');
   }
   opts.dryRun && console.log('=== dry-run ===');
-  if (typeof cb === 'function') cb();
+  typeof cb === 'function' && cb();
   return pathExists;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, rmSync, statSync, unlinkSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, rmSync, statSync, unlinkSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { globSync } from 'tinyglobby';
 
 import type { RemoveOptions } from './interfaces.js';


### PR DESCRIPTION
I think the previous usage of `readdirSync` and `removeSync` was deleting sub-folder outside of their expected paths which caused unexpected folder removal. We can simply use `rmSync(path, { recursive: true })` and that should be enough